### PR TITLE
Tenta adicionar a foto de um strogonoff

### DIFF
--- a/lasanha.md
+++ b/lasanha.md
@@ -1,5 +1,8 @@
 # Strogonoff de Frango
 
+![Foto de um Strogonoff](https://upload.wikimedia.org/wikipedia/commons/thumb/6/68/Beef_Stroganoff%2C_Iran_%28cropped%29.jpg/306px-Beef_Stroganoff%2C_Iran_%28cropped%29.jpg)
+
+
 **Ingredientes**
 
 - 3 peitos de frango cortados em cubos


### PR DESCRIPTION
A imagem é um link externo pra Wikipédia, talvez a gente devesse adicionar o arquivo ao repositório pra nunca correr o risco da imagem ficar fora do ar e a documentação do strogonoff ficar desatualizada?

Tem mais detalhes sobre a imagem e a implementação no corpo da mensagem do único commit dessa pull request. Eu acho que tem um jeito de usar HTML no Markdown do GitHub, então talvez seja possível centralizar essar imagens ou dar uma estilizada nelas usando algum tipo de CSS.